### PR TITLE
feat(routings): use only routings for region; looks like summoner matches depends on summoner region

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ Test modules are most neccessary
  Randomized with seed 912015
 ----------------
 COV    FILE                                        LINES RELEVANT   MISSED
- 77.7% lib/summoner_watch_dog.ex                      93       18        4
+ 76.4% lib/summoner_watch_dog.ex                      89       17        4
  80.0% lib/summoner_watch_dog/application.ex          36        5        1
- 95.0% lib/summoner_watch_dog/oban/summoner_wor      109       20        1
+ 90.9% lib/summoner_watch_dog/oban/summoner_wor       73       11        1
   0.0% lib/summoner_watch_dog/repo.ex                  5        0        0
   0.0% lib/summoner_watch_dog/schema.ex               10        0        0
- 87.8% lib/summoner_watch_dog/seraphine/connect      150       41        5
+ 90.0% lib/summoner_watch_dog/seraphine/connect      136       30        3
 100.0% lib/summoner_watch_dog/summoner_matches.       34        6        0
 100.0% lib/summoner_watch_dog/summoners.ex            32        6        0
 100.0% lib/summoner_watch_dog/summoners/summone       28        2        0
@@ -90,9 +90,9 @@ COV    FILE                                        LINES RELEVANT   MISSED
 100.0% lib/summoner_watch_dog_web/router.ex           15        2        0
  80.0% lib/summoner_watch_dog_web/telemetry.ex        92        5        1
 100.0% test/support/conn_case.ex                      38        2        0
- 57.1% test/support/data_case.ex                      62        7        3
+100.0% test/support/data_case.ex                      46        4        0
 100.0% test/support/factory.ex                        21        3        0
-[TOTAL]  88.3%
+[TOTAL]  90.4%
 ---------------
 
 ```

--- a/lib/summoner_watch_dog.ex
+++ b/lib/summoner_watch_dog.ex
@@ -48,7 +48,7 @@ defmodule SummonerWatchDog do
     matches_count = config()[:matches_count] || @default_matches_count
 
     with {:ok, puuid} <- Connector.get_puuid_by_name(region, URI.encode(summoner_name)),
-         {:ok, summoners} <- Connector.list_matches_participants(puuid, matches_count) do
+         {:ok, summoners} <- Connector.list_matches_participants(puuid, region, matches_count) do
       summoners = Enum.filter(summoners, &(&1.puuid != puuid))
 
       SummonerWorker.enqueue_store(summoner_name, region, puuid)

--- a/test/seraphine/connector_test.exs
+++ b/test/seraphine/connector_test.exs
@@ -37,6 +37,32 @@ defmodule SummonerWatchDog.Seraphine.ConnectorTest do
     test "works for all regions" do
       puuid = gen_remote_id()
 
+      expect(Seraphine.API.RiotAPIBase, :get, fn
+        "https://americas.api.riotgames.com/lol/match/v5/matches/by-puuid/" <> _, _ ->
+          {:ok,
+           %{
+             status_code: 200,
+             body:
+               ~s(["BR1_2919896148", "BR1_2919892164", "BR1_2919801004", "BR1_2919772367", "BR1_2919749258"]),
+             headers: []
+           }}
+      end)
+
+      assert {:ok,
+              [
+                "BR1_2919896148",
+                "BR1_2919892164",
+                "BR1_2919801004",
+                "BR1_2919772367",
+                "BR1_2919749258"
+              ]} = Connector.list_summoner_matches("br1", puuid, 5)
+    end
+  end
+
+  describe "list_matches_participants/2" do
+    test "fetches summonres summoner played with" do
+      region = "br1"
+
       expect(Seraphine.API.RiotAPIBase, :get, 4, fn
         "https://americas.api.riotgames.com/lol/match/v5/matches/by-puuid/" <> _, _ ->
           {:ok,
@@ -45,47 +71,6 @@ defmodule SummonerWatchDog.Seraphine.ConnectorTest do
              body: ~s(["BR1_2919896148", "BR1_2919892164", "BR1_2919801004"]),
              headers: []
            }}
-
-        "https://asia.api.riotgames.com/lol/match/v5/matches/by-puuid/" <> _, _ ->
-          {:ok, %{status_code: 200, body: ~s(["BR1_2919772367"]), headers: []}}
-
-        "https://europe.api.riotgames.com/lol/match/v5/matches/by-puuid/" <> _, _ ->
-          {:ok, %{status_code: 200, body: ~s(["BR1_2919749258"]), headers: []}}
-
-        "https://sea.api.riotgames.com/lol/match/v5/matches/by-puuid/" <> _, _ ->
-          {:ok, %{status_code: 200, body: ~s([]), headers: []}}
-      end)
-
-      assert {:ok,
-              [
-                "BR1_2919749258",
-                "BR1_2919772367",
-                "BR1_2919896148",
-                "BR1_2919892164",
-                "BR1_2919801004"
-              ]} = Connector.list_summoner_matches(puuid, 5)
-    end
-  end
-
-  describe "list_matches_participants/2" do
-    test "fetches summonres summoner played with" do
-      expect(Seraphine.API.RiotAPIBase, :get, 9, fn
-        "https://americas.api.riotgames.com/lol/match/v5/matches/by-puuid/" <> _, _ ->
-          {:ok,
-           %{
-             status_code: 200,
-             body: ~s(["BR1_2919896148", "BR1_2919892164", "BR1_2919801004"]),
-             headers: []
-           }}
-
-        "https://asia.api.riotgames.com/lol/match/v5/matches/by-puuid/" <> _, _ ->
-          {:ok, %{status_code: 200, body: ~s(["BR1_2919772367"]), headers: []}}
-
-        "https://europe.api.riotgames.com/lol/match/v5/matches/by-puuid/" <> _, _ ->
-          {:ok, %{status_code: 200, body: ~s(["BR1_2919749258"]), headers: []}}
-
-        "https://sea.api.riotgames.com/lol/match/v5/matches/by-puuid/" <> _, _ ->
-          {:ok, %{status_code: 200, body: ~s([]), headers: []}}
 
         # match info
         "https://americas.api.riotgames.com/lol/match/v5/matches/BR1_2919896148" <> _, _ ->
@@ -97,7 +82,7 @@ defmodule SummonerWatchDog.Seraphine.ConnectorTest do
                  info: %{
                    participants: [
                      %{puuid: "p1", summonerName: "America Player 1"},
-                     %{puuid: "p9", summonerName: "Europe Player 9"}
+                     %{puuid: "p9", summonerName: "America Player 9"}
                    ]
                  }
                }),
@@ -130,43 +115,7 @@ defmodule SummonerWatchDog.Seraphine.ConnectorTest do
                    participants: [
                      %{puuid: "p4", summonerName: "America Player 4"},
                      %{puuid: "p5", summonerName: "America Player 5"},
-                     %{puuid: "p6", summonerName: "America Player 6"},
-                     %{puuid: "p7", summonerName: "Asia Player 7"}
-                   ]
-                 }
-               }),
-             headers: []
-           }}
-
-        "https://asia.api.riotgames.com/lol/match/v5/matches/BR1_2919772367" <> _, _ ->
-          {:ok,
-           %{
-             status_code: 200,
-             body:
-               Jason.encode!(%{
-                 info: %{
-                   participants: [
-                     %{puuid: "p4", summonerName: "America Player 4"},
-                     %{puuid: "p7", summonerName: "Asia Player 7"},
-                     %{puuid: "p8", summonerName: "Asia Player 8"}
-                   ]
-                 }
-               }),
-             headers: []
-           }}
-
-        "https://europe.api.riotgames.com/lol/match/v5/matches/BR1_2919749258" <> _, _ ->
-          {:ok,
-           %{
-             status_code: 200,
-             body:
-               Jason.encode!(%{
-                 info: %{
-                   participants: [
-                     %{puuid: "p7", summonerName: "Asia Player 7"},
-                     %{puuid: "p9", summonerName: "Europe Player 9"},
-                     %{puuid: "p10", summonerName: "Europe Player 10"},
-                     %{puuid: "p1", summonerName: "America Player 1"}
+                     %{puuid: "p6", summonerName: "America Player 6"}
                    ]
                  }
                }),
@@ -174,47 +123,33 @@ defmodule SummonerWatchDog.Seraphine.ConnectorTest do
            }}
       end)
 
-      assert {:ok, playes} = Connector.list_matches_participants(gen_remote_id(), 5)
+      assert {:ok, playes} = Connector.list_matches_participants(gen_remote_id(), region, 5)
 
       assert [
                %{puuid: "p1", summoner_name: "America Player 1"},
-               %{puuid: "p10", summoner_name: "Europe Player 10"},
                %{puuid: "p2", summoner_name: "America Player 2"},
                %{puuid: "p3", summoner_name: "America Player 3"},
                %{puuid: "p4", summoner_name: "America Player 4"},
                %{puuid: "p5", summoner_name: "America Player 5"},
                %{puuid: "p6", summoner_name: "America Player 6"},
-               %{puuid: "p7", summoner_name: "Asia Player 7"},
-               %{puuid: "p8", summoner_name: "Asia Player 8"},
-               %{puuid: "p9", summoner_name: "Europe Player 9"}
+               %{puuid: "p9", summoner_name: "America Player 9"}
              ] = Enum.sort_by(playes, & &1.puuid)
     end
 
-    test "fails when get matches for one of regions" do
-      expect(Seraphine.API.RiotAPIBase, :get, 2, fn
+    test "fails when get matches for region" do
+      expect(Seraphine.API.RiotAPIBase, :get, fn
         "https://americas.api.riotgames.com/lol/match/v5/matches/by-puuid/" <> _, _ ->
-          {:ok,
-           %{
-             status_code: 200,
-             body: ~s(["BR1_2919896148", "BR1_2919892164", "BR1_2919801004"]),
-             headers: []
-           }}
-
-        _, _ ->
           {:ok, %{status_code: 403, body: ~s(Token expired), headers: []}}
       end)
 
-      assert {:error, :list_match_participants_failed} =
-               Connector.list_matches_participants(gen_remote_id(), 5)
+      assert {:error, :list_matches_failed} =
+               Connector.list_matches_participants(gen_remote_id(), "br1", 5)
     end
 
     test "fails when get participants for one of matches" do
-      expect(Seraphine.API.RiotAPIBase, :get, 4, fn
+      expect(Seraphine.API.RiotAPIBase, :get, 3, fn
         "https://americas.api.riotgames.com/lol/match/v5/matches/by-puuid/" <> _, _ ->
-          {:ok, %{status_code: 200, body: ~s(["BR1_2919896148"]), headers: []}}
-
-        "https://asia.api.riotgames.com/lol/match/v5/matches/by-puuid/" <> _, _ ->
-          {:ok, %{status_code: 200, body: ~s(["BR1_2919749258"]), headers: []}}
+          {:ok, %{status_code: 200, body: ~s(["BR1_2919896148", "BR1_2919749258"]), headers: []}}
 
         # match info
         "https://americas.api.riotgames.com/lol/match/v5/matches/BR1_2919896148" <> _, _ ->
@@ -233,7 +168,7 @@ defmodule SummonerWatchDog.Seraphine.ConnectorTest do
              headers: []
            }}
 
-        "https://asia.api.riotgames.com/lol/match/v5/matches/BR1_2919749258" <> _, _ ->
+        "https://americas.api.riotgames.com/lol/match/v5/matches/BR1_2919749258" <> _, _ ->
           {:ok,
            %{
              status_code: 410,
@@ -243,7 +178,7 @@ defmodule SummonerWatchDog.Seraphine.ConnectorTest do
       end)
 
       assert {:error, :list_match_participants_failed} =
-               Connector.list_matches_participants(gen_remote_id(), 5)
+               Connector.list_matches_participants(gen_remote_id(), "br1", 5)
     end
   end
 end

--- a/test/summoner_watch_dog_test.exs
+++ b/test/summoner_watch_dog_test.exs
@@ -26,12 +26,8 @@ defmodule SummonerWatchDogTest do
       names = SummonerWatchDog.list_summoners_played_with(@region, @name)
 
       assert [
-               "Asia Player 7",
-               "Europe Player 9",
-               "Europe Player 10",
                "America Player 1",
                "America Player 4",
-               "Asia Player 8",
                "America Player 5",
                "America Player 6",
                "America Player 2",
@@ -39,12 +35,8 @@ defmodule SummonerWatchDogTest do
              ] == names
 
       for {puuid, name} <- [
-            {"p7", "Asia Player 7"},
-            {"p9", "Europe Player 9"},
-            {"p10", "Europe Player 10"},
             {"p1", "America Player 1"},
             {"p4", "America Player 4"},
-            {"p8", "Asia Player 8"},
             {"p5", "America Player 5"},
             {"p6", "America Player 6"},
             {"p2", "America Player 2"},
@@ -73,12 +65,8 @@ defmodule SummonerWatchDogTest do
       expect_match_participants()
 
       assert [
-               "Asia Player 7",
-               "Europe Player 9",
-               "Europe Player 10",
                "America Player 1",
                "America Player 4",
-               "Asia Player 8",
                "America Player 5",
                "America Player 6",
                "America Player 2",
@@ -96,23 +84,15 @@ defmodule SummonerWatchDogTest do
   end
 
   defp expect_match_participants do
-    expect(Seraphine.API.RiotAPIBase, :get, 9, fn
+    expect(Seraphine.API.RiotAPIBase, :get, 6, fn
       "https://americas.api.riotgames.com/lol/match/v5/matches/by-puuid/#{@puuid}" <> _, _ ->
         {:ok,
          %{
            status_code: 200,
-           body: ~s(["BR1_2919896148", "BR1_2919892164", "BR1_2919801004"]),
+           body:
+             ~s(["BR1_2919896148", "BR1_2919892164", "BR1_2919801004", "BR1_2919772367", "BR1_2919749258"]),
            headers: []
          }}
-
-      "https://asia.api.riotgames.com/lol/match/v5/matches/by-puuid/#{@puuid}" <> _, _ ->
-        {:ok, %{status_code: 200, body: ~s(["BR1_2919772367"]), headers: []}}
-
-      "https://europe.api.riotgames.com/lol/match/v5/matches/by-puuid/#{@puuid}" <> _, _ ->
-        {:ok, %{status_code: 200, body: ~s(["BR1_2919749258"]), headers: []}}
-
-      "https://sea.api.riotgames.com/lol/match/v5/matches/by-puuid/#{@puuid}" <> _, _ ->
-        {:ok, %{status_code: 200, body: ~s([]), headers: []}}
 
       # match info
       "https://americas.api.riotgames.com/lol/match/v5/matches/BR1_2919896148" <> _, _ ->
@@ -123,8 +103,7 @@ defmodule SummonerWatchDogTest do
              Jason.encode!(%{
                info: %{
                  participants: [
-                   %{puuid: "p1", summonerName: "America Player 1"},
-                   %{puuid: "p9", summonerName: "Europe Player 9"}
+                   %{puuid: "p1", summonerName: "America Player 1"}
                  ]
                }
              }),
@@ -157,15 +136,14 @@ defmodule SummonerWatchDogTest do
                  participants: [
                    %{puuid: "p4", summonerName: "America Player 4"},
                    %{puuid: "p5", summonerName: "America Player 5"},
-                   %{puuid: "p6", summonerName: "America Player 6"},
-                   %{puuid: "p7", summonerName: "Asia Player 7"}
+                   %{puuid: "p6", summonerName: "America Player 6"}
                  ]
                }
              }),
            headers: []
          }}
 
-      "https://asia.api.riotgames.com/lol/match/v5/matches/BR1_2919772367" <> _, _ ->
+      "https://americas.api.riotgames.com/lol/match/v5/matches/BR1_2919772367" <> _, _ ->
         {:ok,
          %{
            status_code: 200,
@@ -173,16 +151,14 @@ defmodule SummonerWatchDogTest do
              Jason.encode!(%{
                info: %{
                  participants: [
-                   %{puuid: "p4", summonerName: "America Player 4"},
-                   %{puuid: "p7", summonerName: "Asia Player 7"},
-                   %{puuid: "p8", summonerName: "Asia Player 8"}
+                   %{puuid: "p4", summonerName: "America Player 4"}
                  ]
                }
              }),
            headers: []
          }}
 
-      "https://europe.api.riotgames.com/lol/match/v5/matches/BR1_2919749258" <> _, _ ->
+      "https://americas.api.riotgames.com/lol/match/v5/matches/BR1_2919749258" <> _, _ ->
         {:ok,
          %{
            status_code: 200,
@@ -190,9 +166,6 @@ defmodule SummonerWatchDogTest do
              Jason.encode!(%{
                info: %{
                  participants: [
-                   %{puuid: "p7", summonerName: "Asia Player 7"},
-                   %{puuid: "p9", summonerName: "Europe Player 9"},
-                   %{puuid: "p10", summonerName: "Europe Player 10"},
                    %{puuid: "p1", summonerName: "America Player 1"}
                  ]
                }

--- a/test/summoner_watch_dog_web/controllers/summoner_controller_test.exs
+++ b/test/summoner_watch_dog_web/controllers/summoner_controller_test.exs
@@ -12,23 +12,15 @@ defmodule SummonerWatchDogWeb.SummonerControllerTest do
       end
     )
 
-    expect(Seraphine.API.RiotAPIBase, :get, 9, fn
+    expect(Seraphine.API.RiotAPIBase, :get, 6, fn
       "https://americas.api.riotgames.com/lol/match/v5/matches/by-puuid/#{@puuid}" <> _, _ ->
         {:ok,
          %{
            status_code: 200,
-           body: ~s(["BR1_2919896148", "BR1_2919892164", "BR1_2919801004"]),
+           body:
+             ~s(["BR1_2919896148", "BR1_2919892164", "BR1_2919801004", "BR1_2919772367", "BR1_2919749258"]),
            headers: []
          }}
-
-      "https://asia.api.riotgames.com/lol/match/v5/matches/by-puuid/#{@puuid}" <> _, _ ->
-        {:ok, %{status_code: 200, body: ~s(["BR1_2919772367"]), headers: []}}
-
-      "https://europe.api.riotgames.com/lol/match/v5/matches/by-puuid/#{@puuid}" <> _, _ ->
-        {:ok, %{status_code: 200, body: ~s(["BR1_2919749258"]), headers: []}}
-
-      "https://sea.api.riotgames.com/lol/match/v5/matches/by-puuid/#{@puuid}" <> _, _ ->
-        {:ok, %{status_code: 200, body: ~s([]), headers: []}}
 
       # match info
       "https://americas.api.riotgames.com/lol/match/v5/matches/BR1_2919896148" <> _, _ ->
@@ -39,8 +31,7 @@ defmodule SummonerWatchDogWeb.SummonerControllerTest do
              Jason.encode!(%{
                info: %{
                  participants: [
-                   %{puuid: "p1", summonerName: "America Player 1"},
-                   %{puuid: "p9", summonerName: "Europe Player 9"}
+                   %{puuid: "p1", summonerName: "America Player 1"}
                  ]
                }
              }),
@@ -73,15 +64,14 @@ defmodule SummonerWatchDogWeb.SummonerControllerTest do
                  participants: [
                    %{puuid: "p4", summonerName: "America Player 4"},
                    %{puuid: "p5", summonerName: "America Player 5"},
-                   %{puuid: "p6", summonerName: "America Player 6"},
-                   %{puuid: "p7", summonerName: "Asia Player 7"}
+                   %{puuid: "p6", summonerName: "America Player 6"}
                  ]
                }
              }),
            headers: []
          }}
 
-      "https://asia.api.riotgames.com/lol/match/v5/matches/BR1_2919772367" <> _, _ ->
+      "https://americas.api.riotgames.com/lol/match/v5/matches/BR1_2919772367" <> _, _ ->
         {:ok,
          %{
            status_code: 200,
@@ -89,16 +79,14 @@ defmodule SummonerWatchDogWeb.SummonerControllerTest do
              Jason.encode!(%{
                info: %{
                  participants: [
-                   %{puuid: "p4", summonerName: "America Player 4"},
-                   %{puuid: "p7", summonerName: "Asia Player 7"},
-                   %{puuid: "p8", summonerName: "Asia Player 8"}
+                   %{puuid: "p4", summonerName: "America Player 4"}
                  ]
                }
              }),
            headers: []
          }}
 
-      "https://europe.api.riotgames.com/lol/match/v5/matches/BR1_2919749258" <> _, _ ->
+      "https://americas.api.riotgames.com/lol/match/v5/matches/BR1_2919749258" <> _, _ ->
         {:ok,
          %{
            status_code: 200,
@@ -106,9 +94,6 @@ defmodule SummonerWatchDogWeb.SummonerControllerTest do
              Jason.encode!(%{
                info: %{
                  participants: [
-                   %{puuid: "p7", summonerName: "Asia Player 7"},
-                   %{puuid: "p9", summonerName: "Europe Player 9"},
-                   %{puuid: "p10", summonerName: "Europe Player 10"},
                    %{puuid: "p1", summonerName: "America Player 1"}
                  ]
                }
@@ -118,12 +103,8 @@ defmodule SummonerWatchDogWeb.SummonerControllerTest do
     end)
 
     assert [
-             "Asia Player 7",
-             "Europe Player 9",
-             "Europe Player 10",
              "America Player 1",
              "America Player 4",
-             "Asia Player 8",
              "America Player 5",
              "America Player 6",
              "America Player 2",

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -43,20 +43,4 @@ defmodule SummonerWatchDog.DataCase do
     pid = Ecto.Adapters.SQL.Sandbox.start_owner!(SummonerWatchDog.Repo, shared: not tags[:async])
     on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
   end
-
-  @doc """
-  A helper that transforms changeset errors into a map of messages.
-
-      assert {:error, changeset} = Accounts.create_user(%{password: "short"})
-      assert "password is too short" in errors_on(changeset).password
-      assert %{password: ["password is too short"]} = errors_on(changeset)
-
-  """
-  # def errors_on(changeset) do
-  #   Ecto.Changeset.traverse_errors(changeset, fn {message, opts} ->
-  #     Regex.replace(~r"%{(\w+)}", message, fn _, key ->
-  #       opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
-  #     end)
-  #   end)
-  # end
 end


### PR DESCRIPTION
looks like summoner matches depends on summoner region
Do not search matches in all routings and regions
I am not sure does Riot allow sea summoners to plat in asia region - looks like not, so code that check all routings/regions removed 